### PR TITLE
Using request library instead of a proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "body-parser": "^1.14.1",
     "express": "^4.13.3",
-    "express-http-proxy": "^0.6.0",
     "express-session": "^1.11.3",
-    "http-proxy": "^1.11.2"
+    "request": "^2.64.0"
   }
 }


### PR DESCRIPTION
This other approach uses [request](https://www.npmjs.com/package/request) library without using any kind of external proxy library.
